### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/detekt-analysis.yml
+++ b/.github/workflows/detekt-analysis.yml
@@ -62,7 +62,7 @@ jobs:
           }
         ' | \
         jq --raw-output '.data.repository.release.releaseAssets.nodes[0].downloadUrl' )
-        echo "download_url=$DETEKT_DOWNLOAD_URL" >> $GITHUB_OUTPUT
+        echo "download_url=$DETEKT_DOWNLOAD_URL" >> "$GITHUB_OUTPUT"
 
     # Sets up the detekt cli
     - name: Setup Detekt

--- a/.github/workflows/detekt-analysis.yml
+++ b/.github/workflows/detekt-analysis.yml
@@ -62,7 +62,7 @@ jobs:
           }
         ' | \
         jq --raw-output '.data.repository.release.releaseAssets.nodes[0].downloadUrl' )
-        echo "::set-output name=download_url::$DETEKT_DOWNLOAD_URL"
+        echo "download_url=$DETEKT_DOWNLOAD_URL" >> $GITHUB_OUTPUT
 
     # Sets up the detekt cli
     - name: Setup Detekt


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter


